### PR TITLE
Add a simple flake.

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ typings/
 # CI build stuff
 ci/venv
 ci/build
+
+# nix stuff
+.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,41 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1680242334,
+        "narHash": "sha256-HlCbTg1oj6cWLtdQ9Gi8p27t4bde9cSWgtmWrBXdh8w=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f30990fc98b8468eba13d75f6c4c2190a61073ea",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,20 @@
+{
+  description = "rust-install";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        lib = import <nixpkgs/lib>;
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      rec {
+        devShell = pkgs.mkShell {
+          buildInputs = with pkgs.nodePackages; 
+          [
+            pkgs.nodejs-18_x
+            (pkgs.yarn.override { nodejs = pkgs.nodejs-18_x; })
+          ];
+        };
+      });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -12,8 +12,8 @@
         devShell = pkgs.mkShell {
           buildInputs = with pkgs.nodePackages; 
           [
-            pkgs.nodejs-18_x
-            (pkgs.yarn.override { nodejs = pkgs.nodejs-18_x; })
+            pkgs.nodejs-16_x
+            (pkgs.yarn.override { nodejs = pkgs.nodejs-16_x; })
           ];
         };
       });

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,6 @@
           buildInputs = with pkgs.nodePackages; 
           [
             pkgs.nodejs-16_x
-            (pkgs.yarn.override { nodejs = pkgs.nodejs-16_x; })
           ];
         };
       });


### PR DESCRIPTION
This doesn't pull down node dependencies, and it doesn't help the user set the auth token needed to pull those dependencies.